### PR TITLE
Remove OX_PARALLEL hack to avoid earlier oxdoc shortcomings

### DIFF
--- a/include/Outcomes.h
+++ b/include/Outcomes.h
@@ -16,9 +16,7 @@ struct Outcome : Data {
 
 	static 	decl
 	   /** . @internal **/    AnyMissing
-#ifdef OX_PARALLEL
-                                         = < [DSubSpaces] *0> //Oxdoc does not recognize this syntax so ifdef hides it
-#endif
+                                         = < [DSubSpaces] *0>
      	,
      /** . @internal **/                Rust_Eq_4_15,
     /** . @internal **/                 pathpred,

--- a/source/DDP/Bellman.ox
+++ b/source/DDP/Bellman.ox
@@ -748,11 +748,7 @@ ExPostSmoothing::SetSmoothing(Method,smparam) {
 to add any state variables to the model.</DT>
 
 **/
-OneStateModel::Initialize(UorB,Method,...
-    #ifdef OX_PARALLEL
-    args
-    #endif
-    ) {
+OneStateModel::Initialize(UorB,Method,...args) {
     if (isfunction(UorB)) {
         U = UorB;
         ExPostSmoothing::Initialize(new OneStateModel());

--- a/source/DDP/DP.ox
+++ b/source/DDP/DP.ox
@@ -286,38 +286,28 @@ DP::AddStates(SubV,va) 	{
 /** Add `StateVariable`s to the endogenous vector $\theta$.
 @param ... `StateVariable`s to add to $\theta$
 **/
-DP::EndogenousStates(...
-    #ifdef OX_PARALLEL
-    vs
-    #endif
-    )	{	AddStates(endog,vs); }
+DP::EndogenousStates(...vs) {
+  AddStates(endog,vs);
+}
 
 /** Add `StateVariable`s to the exogenous vector $\epsilon$.
 @param ... Exogenous `StateVariable`s to add $\epsilon$
 **/
-DP::ExogenousStates(...
-    #ifdef OX_PARALLEL
-    vs
-    #endif
-) 	{ AddStates(exog,vs); } 	
+DP::ExogenousStates(...vs) {
+  AddStates(exog,vs);
+}
 
 /** Add `StateVariable`s to the semiexogenous vector $\eta$.
 @param ... Semi-exogenous `StateVariable`s to add to $\eta$
 **/
-DP::SemiExogenousStates(...
-    #ifdef OX_PARALLEL
-    vs
-    #endif
-) 	{ AddStates(semiexog,vs); } 	
+DP::SemiExogenousStates(...vs) {
+  AddStates(semiexog,vs);
+}
 
 /** Add `TimeInvariant`s to the group vector $\gamma$.
 @param ... `TimeInvariant`s to add to $\gamma$
 **/
-DP::GroupVariables(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-)	{
+DP::GroupVariables(...va) {
 	decl cv,ccv;
     foreach(cv in va) {
     	if (isarray(cv)){
@@ -351,11 +341,7 @@ Actions(work = new ActionVariable("w",2));
 @comments
 If no action variables are added to <code>MyModel</code> then a no-choice action is added by `DP::CreateSpaces`().
 **/
-DP::Actions(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) 	{
+DP::Actions(...va) {
 	decl a, i, j, nr, pos=S[acts].D, sL;
     for(i=0;i<sizeof(va);++i)	{
         if (isarray(va[i])) {
@@ -392,11 +378,7 @@ DP::Actions(...
 
 @see DP::Chi, StaticAux
 **/
-DP::AuxiliaryOutcomes(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+DP::AuxiliaryOutcomes(...va) {
 	if (!isarray(SubVectors)) oxrunerror("DDP Error 40. Error: can't add auxiliary before calling Initialize()",0);
 	decl pos = sizeof(Chi), i,j,s;
     foreach(s in va) {
@@ -1792,11 +1774,7 @@ CreateSpaces();
 @comments <code>MyModel</code> can also create a derived `Clock` and pass it to SetClock.
 		
 **/
-DP::SetClock(ClockOrType,...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-)	{
+DP::SetClock(ClockOrType,...va) {
 	if (isclass(counter)) oxrunerror("DDP Error 46. Clock/counter state block already initialized");
 	if (isclass(ClockOrType,"Clock")) {
         counter = ClockOrType;
@@ -2142,11 +2120,7 @@ DPDebug::Initialize() {
 	}
 
 /** . @internal **/
-DPDebug::outSVTrans(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+DPDebug::outSVTrans(...va) {
 	decl rp = new SVT(va);
 	rp -> Traverse();
 	delete rp;

--- a/source/DDP/Outcomes.ox
+++ b/source/DDP/Outcomes.ox
@@ -908,11 +908,7 @@ OutcomeDataSet::MatchToColumn(aORs,LorC) {
             ignored.<br/>
 @param ... continues with object2, LoC2, object3, LorC3, etc.<br/>
 **/
-OutcomeDataSet::ObservedWithLabel(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+OutcomeDataSet::ObservedWithLabel(...va) {
 	decl offset,aORs,LorC,k,bv;
 	if (!Version::MPIserver && Data::Volume>SILENT && isfile(Data::logf) ) fprint(Data::logf,"\nAdded to the observed list: ");
     foreach (aORs in va) {
@@ -942,11 +938,7 @@ OutcomeDataSet::ObservedWithLabel(...
 @comments Does nothing unless variable was already sent to
 `OutcomeDataSet::ObservedWithLabel`();
 **/
-OutcomeDataSet::UnObserved(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+OutcomeDataSet::UnObserved(...va) {
 	decl offset,aORs,k;
 	for (k=0;k<sizeof(va);++k) {
 		aORs = va[k];

--- a/source/DDP/Predictions.ox
+++ b/source/DDP/Predictions.ox
@@ -581,11 +581,7 @@ This routine can be called more than once, but once `PanelPrediction::Predict`()
 been called no more objects can be added to the list.
 
 **/
-PanelPrediction::Tracking(LorC,...
-    #ifdef OX_PARALLEL
-    args
-    #endif
-) {
+PanelPrediction::Tracking(LorC,...args) {
     if (EverPredicted) {
         oxwarning("DDP Warning 12.\n Do not add to tracking list after predictions made ... ignored\n");
         return;
@@ -933,11 +929,7 @@ PredictionDataSet::TrackingMatchToColumn(LorC,mom) {
             FALSE: the <code>NotInData</code> tag will be sent.
 @param ... objects or array of objects to track
 **/
-PredictionDataSet::TrackingWithLabel(InDataOrNot,...
-    #ifdef OX_PARALLEL
-    args
-    #endif
-) {
+PredictionDataSet::TrackingWithLabel(InDataOrNot,...args) {
     decl v, pparg = InDataOrNot ? UseLabel : NotInData;
     PanelPrediction::Tracking(pparg,args);
     }

--- a/source/DDP/StateVariable.ox
+++ b/source/DDP/StateVariable.ox
@@ -1316,11 +1316,7 @@ Coevolving::Transit() {
 @param L label for block
 @param ... list of `Coevolving` states to add to the block.
 **/
-StateBlock::StateBlock(L,...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-    )	{
+StateBlock::StateBlock(L,...va) {
 	this.L = L;
 	N= 0;
 	Theta={};
@@ -1336,11 +1332,7 @@ StateBlock::StateBlock(L,...
 @param ... list of `Coevolving` state variables to add to the block.
 The default `StateBlock::Actual` matrix is built up from the actual vectors of variables added to the block.
 **/
-StateBlock::AddToBlock(...
-    #ifdef OX_PARALLEL
-    news
-    #endif
-    )	{
+StateBlock::AddToBlock(...news) {
 	decl i,k,nd,newrow, s, oldallv;
 	//news = {news}|va_arglist();
     foreach(s in news[i]) {   //for (i=0;i<sizeof(news);++i) {

--- a/source/FiveO/Objective.ox
+++ b/source/FiveO/Objective.ox
@@ -436,11 +436,7 @@ To toggle elements of a parameter block ...
 
 @see Objective::ToggleBlockElements
 **/
-Objective::ToggleParams(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+Objective::ToggleParams(...va) {
     decl v,p;
     if (!once) oxrunerror("Must call Load() or Encode() before toggling parameters");
 	foreach (v in va) {
@@ -807,11 +803,7 @@ Constrained::Jacobian() {
 array: any argument can send an array which contains only parameters and blocks	
 @see Parameter,  Objective::Psi
 **/
-Objective::Parameters(...
-    #ifdef OX_PARALLEL
-    args
-    #endif
-) {
+Objective::Parameters(...args) {
 	if (once) oxrunerror("FiveO Error 33. Cannot add parameters after calling Objective::Encode()");
  	decl a, p, b;
      if (!sizeof(args)&&(!Version::MPIserver)) oxwarning("FiveO Warning??.  Parameters called with an empty list");
@@ -1229,11 +1221,7 @@ Equilibrium::Print(orig,fn,toscreen){
 @param ... `Parameter`s and arrays of Parameters to optimize over.
 @comments  `Objective::NvfuncTerms` is set to <code>data.FN</code>, the total number of paths in the panel
 **/
-DataObjective::DataObjective (L,data,...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-    )	{
+DataObjective::DataObjective (L,data,...va) {
     if ( ismember(data,"FN")!=2 || ismember(data,"EconometricObjective")!=1 )
 	       oxrunerror("data must have a FN member and a EconometricObjective method, like Panel and PanelPrediction classes");
 	BlackBox(L);
@@ -1430,11 +1418,7 @@ Separable::Separable(L,Kvar) {
 @param ... `Parameter`(s) and/or arrays of Parameters to add to the objective
 @comment On any call to <code>vfunc()</code> common parameters will have the same value for each <var>k</var>.
 **/
-Separable::Common(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
- ) {
+Separable::Common(...va) {
 	decl cs = sizeof(Psi),m;
 	Objective::Parameters(va);
 	for (m=cs;m<sizeof(Psi);++m) ComInd |= Psi[m].pos;
@@ -1639,11 +1623,7 @@ A single argument, then it must be a D&times;K matrix<br>
 D arguments, then each must be a `ParameterBlock` of size K and<br>
 	Lambda[d] = va[d]    for d = 0, &hellip; D&oline;<br>
 **/
-Mixture::Mixture(L,Dvar,Kvar,MixType,...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-) {
+Mixture::Mixture(L,Dvar,Kvar,MixType,...va) {
 	decl k,d, ll;
 	oxwarning("MIXTURE NOT WORKING YET.  WAIT UNTIL NEXT VERSION");
 	if (isclass(Dvar,"Discrete")) this.Dvar = Dvar;

--- a/source/FiveO/Parameters.ox
+++ b/source/FiveO/Parameters.ox
@@ -251,11 +251,7 @@ ParameterBlock::ParameterBlock(L, ...) {
 @param psi `Parameter` to add.
 @param ... more parameters
 **/
-ParameterBlock::AddToBlock(...
-    #ifdef OX_PARALLEL
-    va
-    #endif
-    )	{
+ParameterBlock::AddToBlock(...va) {
 	decl b;
 	if (pos!=UnInitialized) oxrunerror("FiveO Error 21a. Cannot add to a Block after it has been added to the Objective\n");
     foreach (b in va) {

--- a/source/Shared/oxcgi.ox
+++ b/source/Shared/oxcgi.ox
@@ -2,6 +2,6 @@
 
 main() {
     CGI::Initialize();
-    println(CGI:GetVar("Query_String"));
+    println(CGI::GetVar("Query_String"));
     CGI::Finalize();
     }


### PR DESCRIPTION
Oxdoc now supports `...va` in function arguments and variable-based multiplicative entries in matrix constants.